### PR TITLE
Potential fix for code scanning alert no. 4: Prototype-polluting function

### DIFF
--- a/src/util/general.ts
+++ b/src/util/general.ts
@@ -2,6 +2,10 @@
 export function deepMerge(target: any, source: any): any {
     for (const key in source) {
         if (Object.prototype.hasOwnProperty.call(source, key)) {
+            // Block prototype-polluting keys
+            if (key === '__proto__' || key === 'constructor') {
+                continue;
+            }
             if (source[key] && typeof source[key] === 'object' && !Array.isArray(source[key])) {
                 if (!target[key]) {
                     target[key] = {};


### PR DESCRIPTION
Potential fix for [https://github.com/tobrien/cortalyne/security/code-scanning/4](https://github.com/tobrien/cortalyne/security/code-scanning/4)

To fix the issue, we will modify the `deepMerge` function to explicitly block the special property names `__proto__` and `constructor`. This ensures that these properties cannot be copied from the `source` object to the `target` object, thereby preventing prototype pollution.

- Add a check to skip the keys `__proto__` and `constructor` in the loop that iterates over the `source` object.
- Ensure that this check is applied before any recursive calls or assignments to the `target` object.

The fix will be implemented in the `deepMerge` function in `src/util/general.ts`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
