### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 name: Run Tests
 
+permissions:
+  contents: write
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/tobrien/cortalyne/security/code-scanning/1](https://github.com/tobrien/cortalyne/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the steps in the workflow:
- `contents: read` is required to check out the repository and access its contents.
- `contents: write` is required for the `codecov/codecov-action` step, which uploads coverage reports.

The `permissions` block will be added at the top level of the workflow, ensuring it applies to all jobs unless overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
